### PR TITLE
Add configurability to admin and reader role names

### DIFF
--- a/examples/dbt-quickstart/locals.tf
+++ b/examples/dbt-quickstart/locals.tf
@@ -3,7 +3,7 @@ locals {
   sysadmin_role = "SYSADMIN"
   employees = {
     "EMPLOYEE_A" = {
-      name = "employee.a@immuta.com"
+      name       = "employee.a@immuta.com"
       login_name = "employee.a@immuta.com"
     }
     "EMPLOYEE_B" = {

--- a/examples/dbt-quickstart/main.tf
+++ b/examples/dbt-quickstart/main.tf
@@ -52,7 +52,7 @@ module "analytics_db" {
   for_each = toset(["STAGING", "PROD"])
   source   = "../../modules/application_database"
 
-  database_name = "ANALYTICS_${each.value}"
+  database_name        = "ANALYTICS_${each.value}"
   grant_admin_to_roles = [local.sysadmin_role]
   grant_admin_to_users = [module.systems.users["DBT_CLOUD_USER"].name]
   grant_read_to_roles = [
@@ -67,7 +67,7 @@ module "stitch_db" {
   database_name                = "STITCH"
   create_application_user      = true
   create_application_warehouse = true
-  grant_admin_to_roles = [local.sysadmin_role]
+  grant_admin_to_roles         = [local.sysadmin_role]
   grant_read_to_roles = [
     module.bulk_roles.roles["READER"].name,
   ]
@@ -79,7 +79,7 @@ module "fivetran_db" {
   database_name                = "FIVETRAN"
   create_application_user      = true
   create_application_warehouse = true
-  grant_admin_to_roles = [local.sysadmin_role]
+  grant_admin_to_roles         = [local.sysadmin_role]
   grant_read_to_roles = [
     module.bulk_roles.roles["READER"].name,
   ]
@@ -91,7 +91,7 @@ module "meltano_db" {
   database_name                = "MELTANO"
   create_application_user      = true
   create_application_warehouse = true
-  grant_admin_to_roles = [local.sysadmin_role]
+  grant_admin_to_roles         = [local.sysadmin_role]
   grant_read_to_roles = [
     module.bulk_roles.roles["READER"].name,
   ]
@@ -126,8 +126,8 @@ module "bulk_warehouse_grants" {
   grants = {
     PROCESSING_WH = {
       roles = concat(
-        [for m in module.analytics_db: m.admin_role.name],
-        [for m in module.developer_dbs: m.admin_role.name],
+        [for m in module.analytics_db : m.admin_role.name],
+        [for m in module.developer_dbs : m.admin_role.name],
         [module.bulk_roles.roles["ANALYST"].name]
       )
     }

--- a/main.tf
+++ b/main.tf
@@ -13,17 +13,17 @@ locals {
 module "employees" {
   source = "./modules/bulk_users"
   users = {
-    "harry"    = {}
-    "ron"      = {
+    "harry" = {}
+    "ron" = {
       first_name = "Ronald"
     }
     "hermione" = {}
-    "fred"     = {
+    "fred" = {
       login_name = "fred"
     }
   }
 
-  default_role = "PUBLIC"
+  default_role                   = "PUBLIC"
   default_generate_user_password = true
 }
 
@@ -38,10 +38,10 @@ module "bulk_warehouses" {
   source = "./modules/bulk_warehouses"
   warehouses = {
     transform = {
-      name = "TRANSFORM_WH"
+      name                    = "TRANSFORM_WH"
       create_resource_monitor = true
     }
-    report    = {
+    report = {
       name = "REPORTING_WH"
       size = "medium"
     }
@@ -79,10 +79,10 @@ module "bulk_warehouse_grants" {
 module "example_db" {
   source = "./modules/application_database"
 
-  database_name       = "ANALYTICS"
+  database_name        = "ANALYTICS"
   grant_admin_to_roles = []
   grant_admin_to_users = [module.employees.users["ron"].name]
-  grant_read_to_roles = [module.bulk_roles.roles["analyst"].name]
+  grant_read_to_roles  = [module.bulk_roles.roles["analyst"].name]
 }
 
 module "developer_dbs" {
@@ -92,5 +92,5 @@ module "developer_dbs" {
   database_name                = module.employees.users[each.key].name
   create_application_user      = false
   create_application_warehouse = false
-  grant_admin_to_users          = [module.employees.users[each.key].name]
+  grant_admin_to_users         = [module.employees.users[each.key].name]
 }

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,8 @@ module "developer_dbs" {
   for_each = toset(local.developer_list)
   source   = "./modules/application_database"
 
-  database_name                = module.employees.users[each.key].name
+  database_name                = "DEV_${module.employees.users[each.key].name}"
+  admin_role_name_suffix       = ""
   create_application_user      = false
   create_application_warehouse = false
   grant_admin_to_users         = [module.employees.users[each.key].name]

--- a/modules/application_database/locals.tf
+++ b/modules/application_database/locals.tf
@@ -1,18 +1,21 @@
 locals {
-  create_warehouse_monitor = var.create_application_warehouse && var.create_application_warehouse_monitor
-  database_name            = upper(var.database_name)
+  admin_role_name           = upper("${snowflake_database.app.name}${var.admin_role_name_suffix}")
+  create_reader_role_grants = length(var.grant_read_to_roles) > 0 || length(var.grant_read_to_users) > 0 ? 1 : 0
+  create_warehouse_monitor  = var.create_application_warehouse && var.create_application_warehouse_monitor
+  database_name             = upper(var.database_name)
   grant_admin_to_users = (
     var.create_application_user ?
     concat(var.grant_admin_to_users, [snowflake_user.app[0].name]) :
     var.grant_admin_to_users
   )
+  reader_role_name = upper("${snowflake_database.app.name}${var.reader_role_name_suffix}")
   user_default_warehouse = (
     var.create_application_warehouse ?
     coalesce(var.application_user_default_warehouse, local.warehouse_name) :
     var.application_user_default_warehouse
   )
-  create_reader_role_grants = length(var.grant_read_to_roles) > 0 || length(var.grant_read_to_users) > 0 ? 1 : 0
-  user_name                 = upper("${var.database_name}_USER")
-  warehouse_name            = upper("${var.database_name}_WH")
-  warehouse_monitor_name    = upper("${local.warehouse_name}_MONITOR")
+
+  user_name              = upper("${var.database_name}_USER")
+  warehouse_name         = upper("${var.database_name}_WH")
+  warehouse_monitor_name = upper("${local.warehouse_name}_MONITOR")
 }

--- a/modules/application_database/main.tf
+++ b/modules/application_database/main.tf
@@ -20,7 +20,7 @@ resource "snowflake_database" "app" {
 
 // application admin and reader roles
 resource "snowflake_role" "admin" {
-  name    = snowflake_database.app.name
+  name    = local.admin_role_name
   comment = var.description
 }
 
@@ -31,7 +31,7 @@ resource "snowflake_role_grants" "admin" {
 }
 
 resource "snowflake_role" "reader" {
-  name    = "${snowflake_database.app.name}_READER"
+  name    = local.reader_role_name
   comment = var.description
 }
 

--- a/modules/application_database/main.tf
+++ b/modules/application_database/main.tf
@@ -25,7 +25,7 @@ resource "snowflake_role" "admin" {
 }
 
 resource "snowflake_role_grants" "admin" {
-  role_name = snowflake_role.admin.name
+  role_name = snowflake_role.admin.nameterr
   roles     = var.grant_admin_to_roles
   users     = local.grant_admin_to_users
 }

--- a/modules/application_database/privileges.tf
+++ b/modules/application_database/privileges.tf
@@ -83,7 +83,7 @@ resource "snowflake_schema_grant" "public_read" {
   for_each = toset(local.reader_privileges["schema"])
 
   database_name = snowflake_database.app.name
-  schema_name     = local.public_schema_name
+  schema_name   = local.public_schema_name
   privilege     = each.key
   roles         = local.all_read_roles
 }
@@ -129,7 +129,7 @@ resource "snowflake_schema_grant" "public_admin" {
   for_each = toset(local.admin_privileges["schema"])
 
   database_name = snowflake_database.app.name
-  schema_name     = local.public_schema_name
+  schema_name   = local.public_schema_name
   privilege     = each.key
   roles         = local.all_admin_roles
 }

--- a/modules/application_database/variables.tf
+++ b/modules/application_database/variables.tf
@@ -16,6 +16,12 @@ variable "create_application_warehouse_monitor" {
   type        = bool
 }
 
+variable "admin_role_name_suffix" {
+  default     = "_ADMIN"
+  description = "The suffix appended to the database name to determine the admin role (e.g. APP_ADMIN)."
+  type        = string
+}
+
 variable "application_user_default_warehouse" {
   default     = null
   description = "The name of the default warehouse to be used by the database_user. Only used when creating a user but not creating a warehouse."
@@ -73,4 +79,10 @@ variable "grant_read_to_users" {
   default     = []
   description = "Additional users that should have read access to module resources."
   type        = list(string)
+}
+
+variable "reader_role_name_suffix" {
+  default     = "_READER"
+  description = "The suffix appended to the database name to determine the reader role (e.g. APP_READER)."
+  type        = string
 }

--- a/modules/bulk_roles/variables.tf
+++ b/modules/bulk_roles/variables.tf
@@ -2,8 +2,8 @@ variable "roles" {
   default     = {}
   description = "Map of roles to create. 'name' required. Values from the 'snowflake_user' resource will be applied. 'name' is required."
   type = map(object({
-      name    = optional(string)
-      comment = optional(string)
+    name    = optional(string)
+    comment = optional(string)
     })
   )
 }

--- a/modules/bulk_users/variables.tf
+++ b/modules/bulk_users/variables.tf
@@ -2,20 +2,19 @@ variable "users" {
   default     = {}
   description = "Map of users to be created. Values from the 'snowflake_user' resource will be applied. 'name' is required."
   type = map(object({
-      name                   = optional(string)
-      comment                = optional(string)
-      display_name           = optional(string)
-      email                  = optional(string)
-      first_name             = optional(string)
-      last_name              = optional(string)
-      login_name             = optional(string)
-      default_namespace      = optional(string)
-      default_role           = optional(string)
-      default_warehouse      = optional(string)
-      must_change_password   = optional(bool)
-      generate_user_password = optional(bool)
-    }
-    )
+    name                   = optional(string)
+    comment                = optional(string)
+    display_name           = optional(string)
+    email                  = optional(string)
+    first_name             = optional(string)
+    last_name              = optional(string)
+    login_name             = optional(string)
+    default_namespace      = optional(string)
+    default_role           = optional(string)
+    default_warehouse      = optional(string)
+    must_change_password   = optional(bool)
+    generate_user_password = optional(bool)
+    })
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,13 +10,13 @@ variable "snowflake_region" {
 
 variable "snowflake_username" {
   description = "The username for the Snowflake Terraform user"
-  sensitive = true
+  sensitive   = true
   type        = string
 }
 
 variable "snowflake_user_password" {
   description = "The password for the Snowflake Terraform user"
-  sensitive = true
+  sensitive   = true
   type        = string
 }
 


### PR DESCRIPTION
This allows users to specify a custom role suffix for their admin and reader roles. For example, `SEGMENT` instead of `SEGMENT_ADMIN`. 

- Add name suffix variables
- Update example
